### PR TITLE
Fix shield restriction patch for RimWorld 1.5

### DIFF
--- a/ShieldWeaponRestriction/HarmonyPatches.cs
+++ b/ShieldWeaponRestriction/HarmonyPatches.cs
@@ -14,10 +14,11 @@ namespace ShieldWeaponRestriction
         }
     }
 
-    [HarmonyPatch(typeof(Pawn_EquipmentTracker), nameof(Pawn_EquipmentTracker.TryAddEquipment))]
-    public static class Patch_TryAddEquipment
+    [HarmonyPatch(typeof(Pawn_EquipmentTracker))]
+    [HarmonyPatch("TryAddPrimaryEquipment")]
+    public static class Patch_TryAddPrimaryEquipment
     {
-        static bool Prefix(Pawn_EquipmentTracker __instance, ThingWithComps newEq, bool dropReplacedEquipment, ref bool __result)
+        static bool Prefix(Pawn_EquipmentTracker __instance, ThingWithComps newEq, ref bool __result)
         {
             var pawn = __instance.pawn;
 

--- a/ShieldWeaponRestriction/ShieldWeaponRestriction.csproj
+++ b/ShieldWeaponRestriction/ShieldWeaponRestriction.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>ShieldWeaponRestriction</AssemblyName>
     <RootNamespace>ShieldWeaponRestriction</RootNamespace>
-    <OutputPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\TwoHandedPatch\ShieldWeaponRestriction\Assemblies\</OutputPath>
+    <OutputPath>Assemblies\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,11 +22,11 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="0Harmony">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\TwoHandedPatch\Libs\0Harmony.dll</HintPath>
+      <HintPath>..\Libs\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VFECore">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VanillaExpandedFramework\Assemblies\VFECore.dll</HintPath>
+      <HintPath>Assemblies\VFECore.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- update equipment patch to new `TryAddPrimaryEquipment` method
- use relative paths for `0Harmony` and `VFECore` references

## Testing
- `dotnet build ShieldWeaponRestriction/ShieldWeaponRestriction.csproj` *(fails: The type or namespace name 'RimWorld' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a7fa60e083309982dd5b0fa42e5e